### PR TITLE
Use the /community API path to fetch groups

### DIFF
--- a/DownloadGroupFeed/README.md
+++ b/DownloadGroupFeed/README.md
@@ -6,7 +6,7 @@ This script illustrates the basics of downloading bulk data from group posts and
 
 It shows how to traverse the groups list and filter based on content posted after a timestamp, how to recurse through pages of API results using [cursor-based paging](/docs/graph-api/using-graph-api#paging) and how to use [Field Expansion](/docs/graph-api/using-graph-api#fieldexpansion) on the feed to fetch nested [Comment](/docs/graph-api/reference/object/comments) and [Like](/docs/graph-api/reference/object/likes) counts for each [Post](/docs/workplace/custom-integrations/reference#post) object in a [Group](/docs/workplace/custom-integrations/reference#group) feed.
 
-To run this script, save the code as `download.py`, replace the `YOURTOKEN` and `YOURCOMMUNITYID` fields at the top of the script, and set an appropriate value for the number of days back you want to look, then run the script in a command line as follows:
+To run this script, save the code as `download.py`, replace the `YOURTOKEN` field at the top of the script, and set an appropriate value for the number of days back you want to look, then run the script in a command line as follows:
 
 python download.py
 

--- a/DownloadGroupFeed/download.py
+++ b/DownloadGroupFeed/download.py
@@ -10,7 +10,6 @@ import csv
 import datetime
 # Modify these to suit your needs
 TOKEN = "YOURTOKEN"
-COMMUNITY = "YOURCOMMUNITYID"
 DAYS = 14# No need to modify these
 GRAPH_URL_PREFIX = "https://graph.facebook.com/"
 GROUPS_SUFFIX = "/groups"# Default paging limit for Graph API# No need to modify, unless you're seeing timeouts
@@ -72,7 +71,7 @@ def getGroups(after=None):
     if after:
         params += "&amp;after=" + after
 
-    graph_url = GRAPH_URL_PREFIX + COMMUNITY + GROUPS_SUFFIX + params
+    graph_url = GRAPH_URL_PREFIX + "community" + GROUPS_SUFFIX + params
 
     result = requests.get(graph_url, headers=headers)
     result_json = json.loads(result.text, result.encoding)


### PR DESCRIPTION
Modified to use the new /community API alias for fetching groups from the current community