### PR TITLE
Update GitHub URL for creating issues

### DIFF
--- a/FileAnIssue/app.js
+++ b/FileAnIssue/app.js
@@ -251,7 +251,7 @@ var createGithubIssue = function(title, description, origin_id, permalink_url) {
     console.log('Creating Github Issue',title, description, origin_id, permalink_url);
     githubapi({
         method: 'POST',
-        url: '/' + GITHUB_REPO + '/issues',
+        url: 'repos/' + GITHUB_REPO + '/issues',
         body: JSON.stringify({
             title: title,
             body: description + '\n\n[View on Workplace](' + permalink_url + ')'

--- a/FileAnIssue/app.js
+++ b/FileAnIssue/app.js
@@ -35,6 +35,7 @@ app.use('/webhook/github',bodyParser.json());
  * VERIFY_TOKEN can be any arbitrary value used to validate a webhook
  * SERVER_URL is the root URL for your server
  * GITHUB_TOKEN is your access token for accessing the GitHub API
+ * GITHUB_REPO identifies the GitHub repo you want to file issues on, eg fbsamples/workplace-platform-samples
  *
  */
 


### PR DESCRIPTION
Per the [GitHub docs](https://developer.github.com/v3/issues/#create-an-issue), the issue creation endpoint takes the form `/repos/:owner/:repo/issues`.

Also added a small comment about what the `GITHUB_REPO` environment variable is.