### PR TITLE
Fix the broken documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 This is a collection of sample applications that show the platform features available to custom integrations in Workplace.
 
-To learn more about building custom integrations for Workplace, check out the developer documentation at [https://developers.facebook.com/docs/workplace/integrations/custom-integrations](https://developers.facebook.com/docs/workplace/integrations/custom-integrations).
+To learn more about building custom integrations for Workplace, check out the developer documentation at [https://developers.facebook.com/docs/workplace/custom-integrations-new](https://developers.facebook.com/docs/workplace/custom-integrations-new).
 
 To get started using Workplace, go to [https://www.facebook.com/workplace](https://www.facebook.com/workplace).


### PR DESCRIPTION
Hello!

While I was trying to implement a toy project with Workplace custom integration, I found that the link in `README.md` was broken. I hope this will resolve the developers' confusion while on-boarding with custom integration.


## My current Google's search result
Even Google search seemed to guide to the broken link.
<img width="644" alt="screen shot 2018-06-16 at 2 09 16 pm" src="https://user-images.githubusercontent.com/1323963/41495966-ed768e66-716e-11e8-8b9b-dbc97292003e.png">

## Link changes
* Old link: https://developers.facebook.com/docs/workplace/integrations/custom-integrations
* New link: https://developers.facebook.com/docs/workplace/custom-integrations-newd
