### PR TITLE
Added comment to support adding users to Frontline People Set only

### DIFF
--- a/SupportScripts/Python/UpdateUserFrontlineStatus/update_frontline.py
+++ b/SupportScripts/Python/UpdateUserFrontlineStatus/update_frontline.py
@@ -14,6 +14,7 @@ GRAPH_URL_PREFIX = 'https://graph.facebook.com/'
 # Methods
 def sendModificationRequest(access_token, endpoint, frontline_status):
     headers = buildHeader(access_token)
+    # Remove: , "has_access": "true" to only add users to Frontline set. Only permission 'Manage work profiles' is required.
     body = {"frontline": '{ "is_frontline": ' + frontline_status + ', "has_access": "true" }' }
     result = requests.post(endpoint, headers=headers, data = body)
     print (endpoint + ' changing frontline status to ' + frontline_status + ' -> ' + result.text)


### PR DESCRIPTION
Added comment to only require 'Manage work profiles' permission to add people to people set by removing 
, "has_access": "true" 
from body of request